### PR TITLE
proposal: Dead link checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "awesome-react",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "bluebird": "^2.5.3",
+    "lodash": "^2.4.1",
+    "markdown": "^0.5.0",
+    "request": "^2.51.0"
+  }
+}

--- a/scripts/checkLinks.js
+++ b/scripts/checkLinks.js
@@ -1,0 +1,63 @@
+var Promise = require('bluebird'); // in front in order to promisify libraries
+
+// alphabetized
+var _ = require('lodash');
+var fs = Promise.promisifyAll(require('fs'));
+var markdown = require('markdown').markdown;
+var request = require('request');
+var url = require('url');
+
+function getLinks(tree) {
+  var links = [];
+
+  if (!_.isArray(tree)) {
+    return links;
+  }
+
+  if (tree[0] === 'link') {
+    // Only absolute links
+    var urlObj = url.parse(tree[1].href);
+    if (urlObj.protocol) {
+      links = [tree[1].href];
+    }
+  } else {
+    links = _.flatten(_.map(tree.slice(1), getLinks));
+  }
+  return links;
+}
+
+fs.readFileAsync(__dirname + '/../README.md', 'utf8')
+  .then(function (text) {
+    var tree = markdown.parse(text);
+    var links = getLinks(tree);
+
+    // Get linked pages in parallel
+    Promise.map(links, function (link) {
+      return new Promise(function (resolve, reject) {
+        request.head(link, {rejectUnauthorized: false, timeout: 5000}, function (error, response, body) {
+          // Always resolve (do not fail fast).
+          if (error) {
+            resolve({
+              link: link,
+              error: error
+            });
+          } else {
+            resolve({
+              link: link,
+              status: response.statusCode
+            });
+          }
+        });
+      });
+    }, {concurrency: 10})
+      .then(function (results) {
+        return _.filter(results, function (result) {
+          return result.error || result.status !== 200;
+        });
+      })
+      .then(function (results) {
+        // With bad links, we need to do a little manual confirmation.
+        // For example, if we get an error, it's possible the endpoint does not respond to head.
+        console.log(results);
+      });
+  });


### PR DESCRIPTION
I was going through the resources and noticed `capacitor` is a dead link. To tackle the general problem, I wrote a script to check the README (`node scripts/checkLinks.js`). It found that the following links are 404s:
- http://revelry.co/2014/11/01/what-you-need-to-know-about-react
- https://github.com/josephsavona/capacitor
- http://todomvc.com/labs/architecture-examples/react-backbone

Note: The script also found three false positives from Quora and tutsplus (Quora does not respond to HEAD, and tutsplus is returning 403), so I guess link cleanup can't be fully automated.