### PR TITLE
Add ReactLoop.org to list of communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A collection of awesome React tools, resources, videos and shiny things.
 * IRC network in `#reactjs` channel on freenode
 * [Reactiflux Slack Group](http://reactiflux.com)
 * [React.js Newsletter](http://reactjsnewsletter.com)
+* [ReactLoop.org](http://reactloop.org)
 
 
 #### Tutorials


### PR DESCRIPTION
ReactLoop.org is a Google Reader / Hacker News hybrid that I've set up to keep track of React-related news. It imports links from RSS feeds curated collaboratively [on Github](https://github.com/obvio171/reactloop). I'd appreciate it if it could be added to the list of resources. Feel free to ping me if you have any questions. Thanks!