### PR TITLE
getDOMNode() has been deprecated. Use React.findDOMNode() instead.

### DIFF
--- a/examples/005_external_plugin/markdown_render.html
+++ b/examples/005_external_plugin/markdown_render.html
@@ -17,7 +17,7 @@ var MarkdownEditor = React.createClass({
 		return {value: ' Text attributes *italic*, **bold**, `monospace`.'};
 	},
 	handleChange: function() {
-		this.setState({value: this.refs.textarea.getDOMNode().value});
+		this.setState({value: React.findDOMNode(this.refs.textarea).value});
 	},
 	render: function() {
 		return (

--- a/examples/006_with_http_server/app.jsx
+++ b/examples/006_with_http_server/app.jsx
@@ -88,11 +88,11 @@ var CommentList = React.createClass({
 
 var CommentForm = React.createClass({
   handleSubmit: function() {
-    var author = this.refs.author.getDOMNode().value.trim();
-    var text = this.refs.text.getDOMNode().value.trim();
+    var author = React.findDOMNode(this.refs.author).value.trim();
+    var text = React.findDOMNode(this.refs.text).value.trim();
     this.props.onCommentSubmit({author: author, text: text});
-    this.refs.author.getDOMNode().value = '';
-    this.refs.text.getDOMNode().value = '';
+    React.findDOMNode(this.refs.author).value = '';
+    React.findDOMNode(this.refs.text).value = '';
     return false;
   },
   render: function() {


### PR DESCRIPTION
https://facebook.github.io/react/blog/2015/03/10/react-v0.13.html
https://facebook.github.io/react/docs/component-api.html#getdomnode