### PR TITLE
Adding link to additional tools for React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ A collection of awesome things regarding React ecosystem.
 ##### React Native
 * [Use React Native](http://www.reactnative.com/)
 * [React Native Components](http://react.parts)
+* [Awesome React Native - Like this list, but focused on React Native](https://github.com/jondot/awesome-react-native)
 * [react-native-webpack-server - Build React Native apps with Webpack](https://github.com/mjohnston/react-native-webpack-server)
 
 #### Flux Implementations


### PR DESCRIPTION
I used a resource similar to this one to help get my React Native [audio app](https://github.com/jhabdas/lumpen-radio) off the ground and want to share it with others. You'll notice the repo is aptly named.