### PR TITLE
Add Golang Isomorphic Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ A collection of awesome things regarding React ecosystem.
 * [Server-rendered React components in Rails](http://bensmithett.com/server-rendered-react-components-in-rails/)
 * [Server-rendered React + Flux in Rails](https://github.com/nambrot/rails-webpack-react-flux)
 * [Serverside React Rendering: Isomorphic JavaScript with ReactJS + Node](https://reactjsnews.com/isomorphic-javascript-with-react-node/)
-* [Go React Serverside Rendering Eample](https://github.com/olebedev/go-react-example)
+* [Golang Isomorphic Hot Reloadable/React/Flummox/Css-Module Starter Kit](https://github.com/olebedev/go-starter-kit)
 * [Serverside rendering with React + Hapi](https://github.com/jedireza/hapi-react-views)
 * [Isomorphic React apps in PHP via dnode](http://ericescalante.com/2015/06/07/isomorphic/)
 


### PR DESCRIPTION
Go react example was deprecated and was replaced by the new one.
See: https://github.com/olebedev/go-starter-kit.