### PR TITLE
Fix "File Uploads" heading and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A collection of awesome things regarding React ecosystem.
     - [Testing React Tutorials](#testing-react-tutorials)
     - [Debugging React](#debugging-react)
     - [Authentication and Authorization](#authentication-and-authorization)
-    - [File Uploads](#uploads)
+    - [File Uploads](#file-uploads)
   - [Approach Explanation](#approach-explanation)
   - [React Internals](#react-internals)
 - [Flux](#flux)
@@ -279,6 +279,7 @@ A collection of awesome things regarding React ecosystem.
 ##### Authentication and Authorization
 * [Role-based authorization](http://blog.littleblimp.com/post/109540707808/role-based-authorization-with-react-js)
 * [Adding authentication to your React Flux app](https://auth0.com/blog/2015/04/09/adding-authentication-to-your-react-flux-app/)
+
 ##### File Uploads
 * [Direct uploads to S3 with React, Rails, and Paperclip](http://blog.littleblimp.com/post/119230396893/direct-uploads-to-s3-with-react-rails-and)
 


### PR DESCRIPTION
Fixes the "File Uploads" heading's formatting, which is missing a line break before it. Also fixes the link to the "File Uploads" section in the Table of Contents.