### PR TITLE
Restore the Reactiflux slack team link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A collection of awesome things regarding React ecosystem.
 * [React Subreddit](http://www.reddit.com/r/reactjs/)
 * [React Loop](http://reactloop.org)
 * [React Podcast](http://reactpodcast.com/)
+* [Reactiflux Slack Team](http://www.reactiflux.com/)
 
 #### React Online Playground
 * [React JSFiddle Integration with JSX](https://jsfiddle.net/reactjs/69z2wepo/)


### PR DESCRIPTION
It seems to have been previously added through the merged PR https://github.com/enaqx/awesome-react/pull/76, but it has since disappeared. :/

This restores the link to the signup page for the Reactiflux Slack team.