### PR TITLE
Add React-Native Starter App - Parse.com, Redux, Jest, Immutable (88% coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A collection of awesome things regarding React ecosystem.
   - [React Native Tutorials](#react-native-tutorials)
   - [React Native Development Tools](#react-native-development-tools)
   - [React Native Sample Apps](#react-native-sample-apps)
-  - [React Native Starter](#react-native-boileplate)
+  - [React Native Starter](#react-native-starter)
 - [GraphQL](#graphql)
   - [GraphQL Spec](#graphql-spec)
   - [GraphQL Tutorials](#graphql-tutorials)
@@ -799,7 +799,7 @@ A collection of awesome things regarding React ecosystem.
 * [HackerNews](https://github.com/iSimar/HackerNews-React-Native)
 * [Ziliun](https://github.com/sonnylazuardi/ziliun-react-native)
 
-#### React Native Boilerplate
+#### React Native Starter
 * [Snowflake - React Native iOS & Android with Redux, Parse.com, Jest (88% coverage)](https://github.com/bartonhammond/snowflake)
 
 #### React Native Components

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A collection of awesome things regarding React ecosystem.
   - [React Native Tutorials](#react-native-tutorials)
   - [React Native Development Tools](#react-native-development-tools)
   - [React Native Sample Apps](#react-native-sample-apps)
-  - [React Native Starter](#react-native-boiler)
+  - [React Native Starter](#react-native-boileplate)
 - [GraphQL](#graphql)
   - [GraphQL Spec](#graphql-spec)
   - [GraphQL Tutorials](#graphql-tutorials)
@@ -800,8 +800,8 @@ A collection of awesome things regarding React ecosystem.
 * [Ziliun](https://github.com/sonnylazuardi/ziliun-react-native)
 
 #### React Native Boilerplate
-*
-[Snowflake - React Native iOS & Android with Redux, Parse.com, Jest (88% coverage)](https://github.com/bartonhammond/snowflake)
+* [Snowflake - React Native iOS & Android with Redux, Parse.com, Jest (88% coverage)](https://github.com/bartonhammond/snowflake)
+
 #### React Native Components
 * [react-native-fbsdk - A wrapper around the iOS Facebook SDK](https://github.com/facebook/react-native-fbsdk)
 * [react-native-applinks - AppLinks support for React Native](https://github.com/facebook/react-native-applinks)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A collection of awesome things regarding React ecosystem.
   - [React Native Tutorials](#react-native-tutorials)
   - [React Native Development Tools](#react-native-development-tools)
   - [React Native Sample Apps](#react-native-sample-apps)
+  - [React Native Starter](#react-native-boiler)
 - [GraphQL](#graphql)
   - [GraphQL Spec](#graphql-spec)
   - [GraphQL Tutorials](#graphql-tutorials)
@@ -798,6 +799,9 @@ A collection of awesome things regarding React ecosystem.
 * [HackerNews](https://github.com/iSimar/HackerNews-React-Native)
 * [Ziliun](https://github.com/sonnylazuardi/ziliun-react-native)
 
+#### React Native Boilerplate
+*
+[Snowflake - React Native iOS & Android with Redux, Parse.com, Jest (88% coverage)](https://github.com/bartonhammond/snowflake)
 #### React Native Components
 * [react-native-fbsdk - A wrapper around the iOS Facebook SDK](https://github.com/facebook/react-native-fbsdk)
 * [react-native-applinks - AppLinks support for React Native](https://github.com/facebook/react-native-applinks)


### PR DESCRIPTION
I've released an 𝐎𝐩𝐞𝐧 𝐒𝐨𝐮𝐫𝐜𝐞 𝐒𝐨𝐟𝐭𝐰𝐚𝐫𝐞 project I call 𝑺𝒏𝒐𝒘𝒇𝒍𝒂𝒌𝒆. It's a javascript based application for both iOS and Android Devices. It is written using 𝗥𝗲𝗮𝗰𝘁𝗡𝗮𝘁𝗶𝘃𝗲, 𝗣𝗮𝗿𝘀𝗲.𝗰𝗼𝗺, 𝗥𝗲𝗱𝘂𝘅, 𝗝𝗲𝘀𝘁, 𝗜𝗺𝗺𝘂𝘁𝗮𝗯𝗹𝗲, and other technologies. This release it to help other developers learn how these 𝘁𝗲𝗰𝗵𝗻𝗼𝗹𝗼𝗴𝗶𝗲𝘀 𝘄𝗼𝗿𝗸 𝘀𝗲𝗮𝗺𝗹𝗲𝘀𝘀𝗹𝘆 𝘁𝗼𝗴𝗲𝘁𝗵𝗲𝗿 and take what used to be incredibly difficult to now be very achievable. I would consider it at this time as a "𝗯𝗼𝗶𝗹𝗲𝗿𝗽𝗹𝗮𝘁𝗲" or "𝘀𝘁𝗮𝗿𝘁𝗲𝗿" project that developers can learn from and use as their starting point