### PR TITLE
Add react + react native + nw boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ A collection of awesome things regarding React ecosystem.
 * [A large SPA react / redux set up boilerplate](https://github.com/chen844033231/react-workflow)
 * [React Starterify - Minimal starter kit with ES2015 + Browserify + Gulp + Tests](https://github.com/Granze/react-starterify)
 * [Isomorphic React TypeScript Starter](https://github.com/toddlucas/react-tsx-starter)
+* [React + React native + NW - Mobile, desktop and website Apps with the same code](https://github.com/benoitvallon/react-native-nw-react-calculator)
 
 ##### Components
 * [React Components](http://react-components.com/)


### PR DESCRIPTION
I added a link to this project https://github.com/benoitvallon/react-native-nw-react-calculator which offers a starting point to build a project for mobile, desktop and website apps with the same code. Of course all the code is based on react and react native.

I thought it could be interesting to add it to this awesome list of resources. I added it in the boilerplate section, if you would prefer to have it in another section, let me know.