### PR TITLE
Change travis ci icon link to point to enaqx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### **Awesome React** [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Build Status](https://travis-ci.org/niklabh/awesome-react.svg?branch=master)](https://travis-ci.org/niklabh/awesome-react)
+### **Awesome React** [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Build Status](https://travis-ci.org/enaqx/awesome-react.svg?branch=master)](https://travis-ci.org/enaqx/awesome-react)
 
 
 A collection of awesome things regarding React ecosystem.


### PR DESCRIPTION
Please add repo to https://travis-ci.org/