### PR TITLE
Add react-mobile-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ A collection of awesome things regarding React ecosystem.
 * [react-file-reader-input - Complete control over styling + abstraction from file reading](https://github.com/ngokevin/react-file-reader-input)
 * [react-sortable-pane - Resizable and sortable pane component for React](https://github.com/bokuweb/react-sortable-pane)
 * [react-DnR - Dragable and Resizable window build with React.js](https://github.com/yongxu/react-DnR)
+* [react-mobile-picker - An iOS like select box component for React](https://github.com/adcentury/react-mobile-picker)
 
 ##### Libraries
 * [react-magic - Automatically AJAXify plain HTML with the power of React](https://github.com/reactjs/react-magic)


### PR DESCRIPTION
Add `react-mobile-picker`: an iOS like select box component for React.

![react-mobile-picker](https://raw.githubusercontent.com/adcentury/react-mobile-picker/master/examples/screen-capture.gif)