### PR TITLE
add echarts-for-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ A collection of awesome things regarding React ecosystem.
 * [react-browser-detection - React component to detect browser](https://github.com/mbasso/react-browser-detection)
 * [react-text-mask - Text and `<input/>` masking component](https://github.com/msafi/text-mask)
 * [rebass - Configurable React Stateless Functional UI Components](https://github.com/jxnblk/rebass)
+* [echarts-for-react - baidu Echarts(v3.0) components for React.](https://github.com/hustcc/echarts-for-react)
 
 ##### Libraries
 * [react-magic - Automatically AJAXify plain HTML with the power of React](https://github.com/reactjs/react-magic)

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ A collection of awesome things regarding React ecosystem.
 * [react-browser-detection - React component to detect browser](https://github.com/mbasso/react-browser-detection)
 * [react-text-mask - Text and `<input/>` masking component](https://github.com/msafi/text-mask)
 * [rebass - Configurable React Stateless Functional UI Components](https://github.com/jxnblk/rebass)
-* [echarts-for-react - baidu Echarts(v3.0) components for React.](https://github.com/hustcc/echarts-for-react)
+* [echarts-for-react - baidu Echarts(v3.0) components for React](https://github.com/hustcc/echarts-for-react)
 
 ##### Libraries
 * [react-magic - Automatically AJAXify plain HTML with the power of React](https://github.com/reactjs/react-magic)


### PR DESCRIPTION
echarts is a canvas chart system of baidu. [https://github.com/ecomfe/echarts](https://github.com/ecomfe/echarts)

[echarts-for-react](https://github.com/hustcc/echarts-for-react) is the component for react.

DEMO: [http://git.hust.cc/echarts-for-react/](http://git.hust.cc/echarts-for-react/)