### PR TITLE
Add react-redux-starter-kit (zero build config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A collection of awesome things regarding React ecosystem.
 * [StarHackIt - An ES6/ES7 full-stack starter kit with authentication and authorization code](https://github.com/FredericHeem/starhackit)
 * [react-cordova-boilerplate - TodoMVC example for React to build a Cordova application](https://github.com/unimonkiez/react-cordova-boilerplate)
 * [UniversalRelayBoilerplate - Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Material-UI), Relay, GraphQL, JWT, Node.js, Apache Cassandra](https://github.com/codefoundries/UniversalRelayBoilerplate)
+* [React Redux Starter Kit - Enjoy React, Redux, and React-Router, with zero build configuration](https://github.com/cloudmu/react-redux-starter-kit)
 
 ##### Routing
 * [react-router - A complete routing library for React](https://github.com/reactjs/react-router)


### PR DESCRIPTION
A react starter-kit (boilerplate), newly ported to use create-react-app.