### PR TITLE
Update `react-text-mask` link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ A collection of awesome things regarding React ecosystem.
 * [react-http-request - React component exposes network request functionality](https://github.com/mbasso/react-http-request)
 * [react-https-redirect - Force a redirect to HTTPS when not on a local web server](https://github.com/mbasso/react-https-redirect)
 * [react-browser-detection - React component to detect browser](https://github.com/mbasso/react-browser-detection)
-* [react-text-mask - Text and `<input/>` masking component](https://github.com/msafi/text-mask)
+* [react-text-mask - React input mask](https://github.com/text-mask/text-mask)
 * [rebass - Configurable React Stateless Functional UI Components](https://github.com/jxnblk/rebass)
 * [echarts-for-react - baidu Echarts(v3.0) components for React](https://github.com/hustcc/echarts-for-react)
 * [react-pagespeed-score - A React component for display a dial-type chart of PageSpeed Insights](https://github.com/cauealves/react-pagespeed-score)


### PR DESCRIPTION
Just point to the new location of the library and simplify the description