### PR TITLE
Add ARc to boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ A collection of awesome things regarding React ecosystem.
 * [UniversalRelayBoilerplate - Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Material-UI), Relay, GraphQL, JWT, Node.js, Apache Cassandra](https://github.com/codefoundries/UniversalRelayBoilerplate)
 * [react-boilerplate - A highly scalable, offline-first foundation with the best developer experience and a focus on performance and best practices.](http://reactboilerplate.com)
 * [Next.js - A minimalistic framework for server-rendered React applications](https://zeit.co/blog/next)
+* [ARc - A progressive React starter kit based on Atomic Design](https://arc.js.org)
 
 ##### Routing
 * [react-router - A complete routing library for React](https://github.com/reactjs/react-router)


### PR DESCRIPTION
Hi, guys. [ARc](https://github.com/diegohaz/arc) is a React starter kit based on Atomic Design by Brad Frost and has appeared in 
- Rank 7 on [Mybridge's React.JS Top 10 Articles in October](https://medium.mybridge.co/react-js-top-ten-in-october-48998cdde5a3#.780m20e10)
- Rank 5 on [Top 50 Lightweight JavaScript Plugins & Libraries from 2016](https://speckyboy.com/top-50-javascript-2016/)

I think it would be a nice addition to the list.

@jashmenn 