### PR TITLE
Remove Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### **Awesome React** [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Build Status](https://travis-ci.org/enaqx/awesome-react.svg?branch=master)](https://travis-ci.org/enaqx/awesome-react)
+### **Awesome React** [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 
 A collection of awesome things regarding React ecosystem.


### PR DESCRIPTION
Since new awesome lists [should no longer include a Travis CI badge](https://github.com/sindresorhus/awesome/commit/b7e11cddfae11e1eee1b117b2100e93e3dde1331#diff-081a901bcd6f61bef29110a1bc408818R27), I’d remove it here, too.