### PR TITLE
Add PreJSS to Styling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A collection of awesome things regarding React ecosystem.
 * [Styletron](https://github.com/rtsao/styletron)
 * [TypeStyle](https://github.com/typestyle/typestyle)
 * [styled-components](https://github.com/styled-components/styled-components)
++ [preJSS](https://github.com/axept/prejss)
 
 ##### React Charts Tutorials
 * [Integrating D3.js visualizations in a React app](http://nicolashery.com/integrating-d3js-visualizations-in-a-react-app/)


### PR DESCRIPTION
Dear,

Thanks for you project.

Today we've released PreJSS 1.0:

+ https://github.com/axept/prejss

In a few words, PreJSS is a PostCSS-to-JSS adapter which allows to use any kind of CSS through Tagged Template Strings (like Styled Component) as JSS objects. So probably it's a new approach to work with styles in the middle of PostCSS and JSS.

Could you please merge this PR?