### PR TITLE
fix: correct link for create react npm component

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,7 @@ A collection of awesome things regarding React ecosystem.
 * [ARc - A progressive React starter kit based on Atomic Design](https://arc.js.org)
 * [react-webpack-starter - A simple boiler plate for creating react applications bundled by webpack (using ES6, Babel, SASS and webpack development server)](https://github.com/temilaj/react-webpack-starter)
 * [Happyreaction - React/Spring/Java maven archetype for bootstraping a new project quickly](https://github.com/ignl/happyreaction)
-* [Create React NPM Component - CLI tool for creating a component for distribution on
- +  NPM](https://github.com/deltaskelta/create-react-npm-component)
+* [Create React NPM Component - CLI tool for creating a component for distribution on NPM](https://github.com/deltaskelta/create-react-npm-component)
 
 ##### Routing
 * [react-router - A complete routing library for React](https://github.com/reactjs/react-router)


### PR DESCRIPTION
Link was introduced in https://github.com/enaqx/awesome-react/pull/699 – but not formatted correctly. Now it is 💐