### PR TITLE
Add RemoteRetro application link to Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,7 @@ A collection of awesome things regarding React ecosystem.
 * [brainfock/brainfock](https://github.com/brainfock/brainfock)
 * [HVF/franchise](https://github.com/HVF/franchise)
 * [KELiON/cerebro](https://github.com/KELiON/cerebro)
+* [stride-nyc/remote_retro](https://github.com/stride-nyc/remote_retro), live at [remoteretro.org](https://remoteretro.org)
 
 ---
 ### Contribution

--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ A collection of awesome things regarding React ecosystem.
 * [brainfock/brainfock](https://github.com/brainfock/brainfock)
 * [HVF/franchise](https://github.com/HVF/franchise)
 * [KELiON/cerebro](https://github.com/KELiON/cerebro)
-* [stride-nyc/remote_retro](https://github.com/stride-nyc/remote_retro), live at [remoteretro.org](https://remoteretro.org)
+* [stride-nyc/remote_retro](https://github.com/stride-nyc/remote_retro)
 * [Sqlectron - SQL client](https://sqlectron.github.io/)
 * [ALM tools - an IDE built with and for React + TypeScript](http://alm.tools/)
 


### PR DESCRIPTION
Add RemoteRetro application to Real Apps

 [stride-nyc/remote_retro](https://github.com/stride-nyc/remote_retro), live at [remoteretro.org](https://remoteretro.org)

Thanks!