### PR TITLE
feat: add css in js playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A collection of awesome things regarding React ecosystem.
 ##### React styling
 * [React: CSS in JS](http://blog.vjeux.com/2014/javascript/react-css-in-js-nationjs.html)
 * [React: CSS in JS techniques comparison](https://github.com/MicheleBertoli/css-in-js)
+* [CSS in JS Playground](https://css-in-js-playground.com)
 * [Radium](https://github.com/FormidableLabs/radium)
 * [jsxstyle](https://github.com/petehunt/jsxstyle)
 * [ReactCSS](https://github.com/casesandberg/reactcss)


### PR DESCRIPTION
CSS in JS Playground is a live-editable comparison of a number of different CSS in JS libraries and techniques (including inline styles :/). This PR adds the link to this resource.

I can swap it to the Github link, as well, not sure which is preferable.

Let me know if there's anything else I can help with/clarify!