### PR TITLE
Add startd

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ A collection of awesome things regarding React ecosystem.
 * [MJML - The only framework that makes responsive-email easy. Based on React](https://mjml.io)
 * [react-tv - React renderer for low memory applications and Packager for TVs](https://github.com/raphamorim/react-tv)
 * [ink - React for interactive command-line apps](https://github.com/vadimdemedes/ink)
+* [startd - turn your react component into a web app, just by installing a local dependency](https://github.com/mgrip/startd)
 
 ##### Components
 * [React Svg Textures - Textures.js ported to React. Fully isomorphic.](https://github.com/finnfiddle/react-svg-textures)


### PR DESCRIPTION
Similar to create-react-app or next.js, startd allows you to create a fully-functioning react-based web app - but in contrast to generating boilerplate via a cli tool, startd works by just installing a local dependency to your existing project.

https://github.com/mgrip/startd