### PR TITLE
Add react-materialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ A collection of awesome things regarding React ecosystem.
 * [VistarMedia Components](http://cmpnt.vistarmedia.com/)
 * [React Topcoat UI components](https://github.com/kjda/react-topui)
 * [react-material - Material design components written with React.js and React Style](https://github.com/SanderSpies/react-material)
+* [react-materialize - Material design for React, powered by Materialize](https://github.com/react-materialize/react-materialize)
 * [react-md - Set of React components and sass files for implementing Google's Material Design](https://github.com/mlaursen/react-md)
 * [material-ui - A CSS Framework and a Set of React Components for Material Design](https://github.com/callemall/material-ui)
 * [ReactSymbols - Pixel perfect UI Kit / Library with ready-to-use components + original Sketch resource file](http://reactsymbols.com)


### PR DESCRIPTION
react-materialize is a material design framework for react, based on materializecss

https://github.com/react-materialize/react-materialize

https://github.com/Dogfalo/materialize