### PR TITLE
Removed react-typeahead-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,6 @@ A collection of awesome things regarding React ecosystem.
 * [react-reactive-form - Angular like reactive forms in React](https://github.com/bietkul/react-reactive-form)
 
 ##### Autocomplete
-* [react-typeahead-search by @tonyspiro](https://github.com/tonyspiro/react-typeahead-search)
 * [react-autocomplete by @rackt - WAI-ARIA compliant React autocomplete](https://github.com/rackt/react-autocomplete)
 * [react-autosuggest by @moroshko - WAI-ARIA compliant React autosuggest component](https://github.com/moroshko/react-autosuggest)
 * [react-autocomplete by @eliseumds- Just tasting some ReactJS + RxJS](https://github.com/eliseumds/react-autocomplete)


### PR DESCRIPTION
[react-typeahead-search](https://github.com/tonyspiro/react-typeahead-search) should be removed from Awesome React because:

* It is no longer maintained - newest commit is 4 years old
* README is of low quality and demo link is not working
* No other documentation then README
* No NPM / community link
* Only one person involved in library
* Library can serve only as a demonstration that autocomplete can be written using jQuery, Bootstrap and React, re-using it in any kind of project would require significant modifications

