### PR TITLE
Add Dnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,7 @@ A collection of awesome things regarding React ecosystem.
 - [Remote Retro – Agile retrospectives for distributed teams](https://github.com/stride-nyc/remote_retro)
 - [Spectrum – Simple, powerful online communities](https://github.com/withspectrum/spectrum)
 - [Mattermost – Open source Slack alternative](https://github.com/mattermost/mattermost-webapp)
+- [Dnote - Simple, encrypted notebook](https://github.com/dnote/dnote)
 
 ---
 


### PR DESCRIPTION
This PR adds Dnote to the "Real apps" category. (https://github.com/dnote/dnote)

It is a free and open source note-taking software built with React. I am the main author. Recently I have been live streaming React development for the project, and from the feedback, I concluded that the community might benefit from a real life, production React app codebase.