### PR TITLE
Added create-react-web-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A collection of awesome things regarding React ecosystem.
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) - React specific linting rules for ESLint
 - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) - Static AST checker for a11y rules on JSX elements
 - [react-axe](https://github.com/dequelabs/react-axe) - Accessibility auditing for React applications
+- [create-react-web-component](https://github.com/Silind/create-react-web-component) - Set up a React App wrapped in a Web Component
 
 ##### React Frameworks
 


### PR DESCRIPTION
Added tool `create-react-web-component`

The tool is inspired by `create-react-app`, and with this tool, you can setup a web app pre-configured to run inside a Web Component, by using the command line.

Example: `npx create-react-web-component` will setup a project.