### PR TITLE
Add react-tiger-transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-motion](https://github.com/chenglou/react-motion) - A spring that solves your animation problems
 - [react-esi](https://github.com/dunglas/react-esi) - React Edge Side Includes
 - [hookstate](https://github.com/avkonst/hookstate) - Modern, very fast and extendable state management for React that is based on hooks
+- [react-tiger-transition](https://github.com/pedrobern/react-tiger-transition) - Full page transitions with react router
 
 ##### React Integration
 


### PR DESCRIPTION
I would like to add [react-tiger-transition](https://github.com/PedroBern/react-tiger-transition).

It has a great [demo/documentation site](https://pedrobern.github.io/react-tiger-transition/).

This package makes easy to do full page transitions with react router.