### PR TITLE
Add react-native-media-clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-native-vector-icons - 3000 Customizable Icons for React Native with support for NavBar/TabBar](https://github.com/oblador/react-native-vector-icons)
 - [react-native-google-signin - Google Signin for React Native](https://github.com/apptailor/react-native-google-signin)
 - [react-native-picker-modal-view](https://github.com/pankod/react-native-picker-modal-view)
+- [react-native-media-clipboard](https://github.com/Jarred-Sumner/react-native-media-clipboard) - get images & URLs from the clipboard in React Native
 
 ---
 


### PR DESCRIPTION
[`react-native-media-clipboard`](https://github.com/Jarred-Sumner/react-native-media-clipboard) lets you get images, URLs, and strings from the clipboard in react-native.

Here's a screenshot from the example app:
<img src="https://user-images.githubusercontent.com/709451/74531227-e895e580-4ee0-11ea-8303-324d9767b5d2.png" height=300 />

Do you think it makes sense to include this in the readme? I open-sourced this from my app an hour ago. No worries if not.