### PR TITLE
added frontity to list of react frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [next.js](https://github.com/zeit/next.js) - The React Framework
 - [gatsby.js](https://github.com/gatsbyjs/gatsby) - Free and open source framework based on React
+- [frontity](https://github.com/frontity/frontity) - Free and open source framework to build super fast WordPress themes using React
 - [react-admin](https://github.com/marmelab/react-admin) - Frontend Framework for building B2B applications on top of REST/GraphQL APIs
 
 ##### React Styling


### PR DESCRIPTION
Added [frontity](https://frontity.org/) to the list of React Frameworks.
Frontity is an open source framework for developing WordPress themes using React JS

- [Repo](https://github.com/frontity/frontity) 
- [Blog](https://blog.frontity.org/) 
- [Community](https://community.frontity.org/) 