### PR TITLE
Fix creativecommons.org issue and adding react component projects based on Bulma and Tailwind CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,4 +802,4 @@ A collection of awesome things regarding the React ecosystem.
 
 This list started as personal collection of interesting things about React. At the time it started React was in beta, there was special script to transform JSX to JS and even Flux was not yet published. React is mainstream now, lots of things happened. Please, do not try to use this list as advertisement board or place for public push of your experiments. Only fully free resources here, please. Your contributions and suggestions are heartily♡ welcome, though. (✿◠‿◠)
 
-[![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
+[![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ A collection of awesome things regarding the React ecosystem.
 - [atlaskit](https://bitbucket.org/atlassian/atlaskit-mk-2) - Atlassian's official UI library, built according to the Atlassian Design Guidelines.
 - [baseweb](https://github.com/uber/baseweb) - Base Web is a foundation for initiating, evolving, and unifying web products.
 - [primereact](https://github.com/primefaces/primereact) - A complete UI Framework for React with 50+ components featuring material, bootstrap and custom themes.
+- [react-bulma-components](https://github.com/couds/react-bulma-components) - React components for Bulma framework
+- [react-bulma](https://github.com/kulakowka/react-bulma) - React.js components for Modern CSS framework based on Flexbox
+- [rbx](https://github.com/dfee/rbx) - The Comprehensive Bulma UI Framework for React
+- [trunx](https://github.com/fibo/trunx) - Super Saiyan React components, son of awesome Bulma, implemented in TypeScript
 
 ##### React Awesome Components
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ A collection of awesome things regarding the React ecosystem.
 - [react-bulma](https://github.com/kulakowka/react-bulma) - React.js components for Modern CSS framework based on Flexbox
 - [rbx](https://github.com/dfee/rbx) - The Comprehensive Bulma UI Framework for React
 - [trunx](https://github.com/fibo/trunx) - Super Saiyan React components, son of awesome Bulma, implemented in TypeScript
+- [tailwind-react-ui](https://github.com/emortlock/tailwind-react-ui) - Super Saiyan React components, son of awesome Bulma, implemented in TypeScript
+- [tails-ui](https://github.com/knipferrc/tails-ui) - Clean UI based on tailwindcss
 
 ##### React Awesome Components
 


### PR DESCRIPTION
It's just Cloudflare returning `521` for `http` requests, so it should be used `https` instead.

```bash
$ curl -I  http://creativecommons.org/publicdomain/zero/1.0/  
HTTP/1.1 521 Origin Down
$ curl -I  https://creativecommons.org/publicdomain/zero/1.0/ 
HTTP/2 200 
```
