### PR TITLE
Update Reaviz URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ A collection of awesome things regarding the React ecosystem.
 - [Victory - A collection of composable React components for building interactive data visualizations](https://github.com/FormidableLabs/victory)
 - [Recharts - A charting library built on D3 with an awesome declarative API](https://github.com/recharts/recharts)
 - [React-ApexCharts - React component for ApexCharts (An Interactive SVG Chart Library)](https://github.com/apexcharts/react-apexcharts)
-- [reaviz](https://github.com/jask-oss/reaviz) - React Data Visualization Library based on D3.js
+- [reaviz](https://github.com/reaviz/reaviz) - React Data Visualization Library based on D3.js
 - [react-vis - A React visualization library designed with the following principles in mind: React-friendly, high-level and customizable, expressive, and industry-strong.](https://github.com/uber/react-vis)
 - [nivo - It provides a rich set of data visualization components, built on top of the D3 and React libraries.](https://github.com/plouc/nivo)
 - [vx - A collection of reusable low-level visualization components. It combines the power of D3 to generate your visualization with the benefits of React for updating the DOM.](https://github.com/hshoff/vx)


### PR DESCRIPTION
[jask-oss/reaviz](https://github.com/jask-oss/reaviz) seems to have been moved to [reaviz/reaviz](https://github.com/reaviz/reaviz)

Closes #1123 