### PR TITLE
Remove link to Formal

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,6 @@ A collection of awesome things regarding the React ecosystem.
 - [formland - A simple, super-flexible, extensible config based form generator](https://github.com/indix/formland)
 - [react-reactive-form - Angular like reactive forms in React](https://github.com/bietkul/react-reactive-form)
 - [unform - ReactJS form library to create uncontrolled form structures with nested fields, validations and much more!](https://github.com/Rocketseat/unform)
-- [Formal - Elegant form management primitives for the react hooks era](https://github.com/iamkevinwolf/formal)
 - [react-hook-form - Performant, flexible and extensible forms with easy to use validation](https://github.com/react-hook-form/react-hook-form)
 
 ##### Autocomplete


### PR DESCRIPTION
The project is stale. The last release was over a year ago and the repository has been archived.

The author was looking for co-maintainers without success: https://github.com/kevinwolfdev/formal/issues/52