### PR TITLE
Add react-json-to-html

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ A collection of awesome things regarding the React ecosystem.
 - [Chartify - React plugin for building charts using CSS.](https://github.com/kis/chartify)
 - [Semiotic - A data visualization framework combining React and D3.](https://github.com/nteract/semiotic)
 - [react-muze - React wrapper for [muze](https://muzejs.org/) (free data visualization library for creating exploratory data visualizations in browser, using WebAssembly)](https://github.com/chartshq/react-muze)
+- [react-json-to-html - A React component that displays JSON objects in a simple HTML table](https://github.com/grizzthedj/react-json-to-html)
 
 ---
 


### PR DESCRIPTION
Would like to add a React component that renders an simple HTML table from a JSON object

Repo: https://github.com/grizzthedj/react-json-to-html
Examples: https://grizzthedj.github.io/react-json-to-html/demo/public/#/