### PR TITLE
Adding vanilla-extract library

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A collection of awesome things regarding the React ecosystem.
 - [aphrodite](https://github.com/Khan/aphrodite) - Framework-agnostic CSS-in-JS with support for server-side rendering, browser prefixing, and minimum CSS generation
 - [linaria](https://github.com/callstack/linaria) - Zero-Runtime CSS in JS
 - [stitches](https://github.com/modulz/stitches) - CSS-in-JS with near-zero runtime, SSR, multi-variant support, and a best-in-class developer experience
+- [vanilla-extract](https://github.com/seek-oss/vanilla-extract) - Zero-runtime Stylesheets-in-TypeScript
 
 ##### React Routing
 


### PR DESCRIPTION
A new 2021 styling library from the co-creator of CSS Modules - [Mark Dalgleish](https://github.com/markdalgleish).