### PR TITLE
Remove broken URL to site that doesn't exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,8 +669,6 @@ for Node.js and TypeScript
 
 ### Videos
 
-#### [reactjsvideos.com](https://www.reactjsvideos.com)
-
 #### Important Talks
 
 - [Pete Hunt: React: Rethinking best practices - JSConf EU 2013](https://www.youtube.com/watch?v=x7cQ3mrcKaY)


### PR DESCRIPTION
The website `reactjsvideos.com` no longer is working. This removes that URL from the README. 