### PR TITLE
add nanostores to state management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A collection of awesome things regarding the React ecosystem.
 - [rxdb](https://github.com/pubkey/rxdb) - A fast, offline-first, reactive database for JavaScript Applications
 - [watermelondb](https://github.com/Nozbe/WatermelonDB) - Reactive & asynchronous database for powerful React and React Native apps
 - [valtio](https://github.com/pmndrs/valtio) - Valtio makes proxy-state simple for React and Vanilla
+- [nanostores](https://github.com/nanostores/nanostores) - A tiny (297 bytes) state manager for React with many atomic tree-shakable stores
 
 #### React Styling
 


### PR DESCRIPTION
I discovered this tool while looking for a simple solution to manage the state of a PWA made with Preact. Nanostores was very useful and works with React too, so I think it deserves a highlight here in this repository for other people to know as well.

- It is a tiny state manager for various frameworks and vanilla JS. It uses many atomic stores and direct manipulation.
- It is small, fast, tree-shakable, and persistent. It uses Size Limit to control size and can save data to localStorage and sync between tabs.