### PR TITLE
add await-promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A collection of awesome things regarding the React ecosystem.
 - [immer](https://github.com/immerjs/immer) - Create the next immutable state by mutating the current one
 - [immutable-js](https://github.com/immutable-js/immutable-js) - Immutable persistent data collections for Javascript
 - [rxdb](https://github.com/pubkey/rxdb) - A fast, offline-first, reactive database for JavaScript Applications
+- [await-promise](https://github.com/initdsg/await-promise) Async React component for awaiting a promise and passing its result to other components
 
 #### React Styling
 


### PR DESCRIPTION
This library helps in fetching data from server component and pass it down to children components. Normally you would await the promise in the server component but this is bad since you have to wait every promises in order to paint something on the website. With this library, it will make the server component display immediately. This library also make use of [Suspense](https://react.dev/reference/react/Suspense) where the component will show a fallback component while waiting for the component to resolve.