### PR TITLE
docs: add React Speech Highlight as the Powerfull text to speech library

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A collection of awesome things regarding the React ecosystem.
 #### React Awesome Components
 
 - [Awesome React Components](https://github.com/brillout/awesome-react-components)
+- [react-speech-highlight](https://github.com/albirrkarim/react-speech-highlight-demo) - React Text to Speech with highlighting the words and sentences that are being spoken using audio files, text to speech API, and web speech synthesis API
 - [react-select](https://github.com/JedWatson/react-select) - The Select Component for React
 - [react-big-calendar](https://github.com/jquense/react-big-calendar) - Calendar component
 - [react-datepicker](https://github.com/Hacker0x01/react-datepicker/) - A simple and reusable datepicker component for React


### PR DESCRIPTION
Hi, I want to introduce my creation about text to speech in react

![image](https://github.com/user-attachments/assets/a7fe4eb1-e428-4118-96e5-05a001e699d7)

**React / Vanilla Speech Highlight** is a powerful library for integrating **text-to-speech** and **real-time word/sentence highlighting** into your web applications. It supports audio files, the **Text-to-Speech API**, and the **Web Speech Synthesis API**, making it ideal for creating interactive, accessible, and dynamic user experiences.

Not just like that it has various flexibility and features. Checkout [my repo](https://github.com/albirrkarim/react-speech-highlight-demo)

I put it in the **React Awesome Components** category

Btw it be categorized as **React Awesome Components**?

Or maybe you prefer to make new category for that?

Here is my suggestion:
- React Accessibility
- React Text To Speech
- React Artifical Intelligence
- React Linguistic

Thanks
