### PR TITLE
Add ziko-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-uploady](https://github.com/rpldy/react-uploady) - Modern file-upload components & hooks for React
 - [downshift](https://github.com/downshift-js/downshift) - React autocomplete, combobox or select dropdown components
 - [react-error-boundary](https://github.com/bvaughn/react-error-boundary) - A React error boundary component that lets you catch errors
+- [ziko-wrapper](https://github.com/zakarialaoui10/ziko-wrapper) - Enables rendering of ZikoJS elements within a React app and embedding React components into ZikoJS.
 
 #### React Testing
 


### PR DESCRIPTION
[ziko-wrapper](https://github.com/zakarialaoui10/ziko-wrapper) Enables rendering of [ZikoJS](https://github.com/zakarialaoui10/ziko.js) elements within a React app and embedding React components into ZikoJS.

Example : 

```js
// HelloFromZiko.js
import {h1} from "ziko"
export default HelloFromZiko=({color})=>{
    return h1(`Hello World, this is a Zikojs component.`).style({
        color
    })
}
```

```jsx
import ZikoWrapper from "ziko-wrapper/react"
import HelloFromZiko from "./HelloFromZiko.js"
export default function App(){
    return (
        <ZikoWrapper>
           <HelloFromZiko 
              color="blue"  
            />
        </ZikoWrapper>
    )
 }
```