### PR TITLE
feat: Added Tolgee

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [formatjs](https://github.com/formatjs/formatjs) - Internationalize your web apps
 - [react-i18next](https://github.com/i18next/react-i18next) - Internationalization for React done right
+- [Tolgee](https://tolgee.io) - Open-source internationalization platform enabling users to translate directly in the React app.
 
 #### React Graphics and Animations
 


### PR DESCRIPTION
Added Tolgee to the Internationalization section.

Reason: Tolgee is open-source and can be self-hosted to translate a React app

About Tolgee:
Modify texts right in the React app. In-context translation that doesn't translate lines of text separately. Machine translation is available on top of a lot of tools for teamwork