### PR TITLE
Add Notifuse to React Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A collection of awesome things regarding the React ecosystem.
 - [remix](https://github.com/remix-run/remix) - Full stack web Framework that lets you focus on the user interface
 - [react-admin](https://github.com/marmelab/react-admin) - A frontend Framework for building B2B applications
 - [refine](https://github.com/refinedev/refine) - Build your React-based CRUD applications, without constraints
-- [vike](https://github.com/vikejs/vike) - The Modular Framework - Next.js & Nuxt alternative 
+- [vike](https://github.com/vikejs/vike) - The Modular Framework - Next.js & Nuxt alternative
 
 #### React Component Libraries
 
@@ -188,7 +188,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [formatjs](https://github.com/formatjs/formatjs) - Internationalize your web apps
 - [react-i18next](https://github.com/i18next/react-i18next) - Internationalization for React done right
-- [react-inltayer](https://github.com/aymericzip/intlayer) - Internationalization focused on maintenability for React 
+- [react-inltayer](https://github.com/aymericzip/intlayer) - Internationalization focused on maintenability for React
 
 #### React Graphics and Animations
 
@@ -213,6 +213,7 @@ A collection of awesome things regarding the React ecosystem.
 - [wave](https://github.com/wavetermdev/waveterm) - An open-source, cross-platform terminal for seamless workflows
 - [readest](https://github.com/readest/readest) - A minimalistic, feature-rich and cross-platform eBook reader
 - [bookcars](https://github.com/aelassas/bookcars) - Car rental platform
+- [notifuse](https://github.com/Notifuse/notifuse) - Modern self-hosted emailing platform to send newsletters & transactional emails
 
 ### React Native
 


### PR DESCRIPTION
## Add Notifuse to React Real Apps

This PR adds Notifuse to the `React Real Apps` section.

**About Notifuse:**
- Open-source & self-hosted emailing platform for newsletters & transactional emails
- Features a React-based console interface built with React 18, TypeScript, Vite, and Ant Design
- Includes a visual email builder with MJML and an embeddable notification center widget
- Production-ready application demonstrating real-world React usage

**Links:**
- GitHub: https://github.com/Notifuse/notifuse
- Live Demo: https://demo.notifuse.com/signin?email=demo@notifuse.com
- Website: https://www.notifuse.com

**Why it fits this category:**
Notifuse is a complete, production React application showcasing modern React development practices including React Router, TanStack Query for state management, Tiptap for rich text editing, and a comprehensive UI built with Ant Design.