### PR TITLE
Add reincharts to React charting libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-vis](https://github.com/uber/react-vis) - Data Visualization Components
 - [nivo](https://github.com/plouc/nivo) - Provides a rich set of data visualization components built on top of the D3 and React libraries
 - [xyflow](https://github.com/xyflow/xyflow) - A customizable React component for building node-based editors and interactive diagrams
+- [reincharts](https://github.com/reincharts/reincharts) - A composable, interactive-first charting library built with D3 and HTML canvas.
 
 #### React Renderers
 


### PR DESCRIPTION
This PR adds Reincharts to the `React Charts` section.

**About Reincharts:**
- Composable charting library for React to build interactive-first charts with only the features you want
- Different series types to display data in different ways
- A focus on interactive charts with the ability to update the scale and add annotations to the chart

**Links:**

GitHub: https://github.com/reincharts/reincharts
Live Demo: https://reincharts.com/storybook/
Website: https://reincharts.com/

**Why it fits this category:**
Reincharts fits in this category alongside the other charting libraries because it can create interactive charts that you can scale and add different annotations (freehand drawings, lines, text boxes, etc.) to, which none of the other libraries have the ability to do. 