### PR TITLE
Add react-state-custom to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A collection of awesome things regarding the React ecosystem.
 - [immer](https://github.com/immerjs/immer) - Create the next immutable state by mutating the current one
 - [immutable-js](https://github.com/immutable-js/immutable-js) - Immutable persistent data collections for Javascript
 - [rxdb](https://github.com/pubkey/rxdb) - A fast, offline-first, reactive database for JavaScript Applications
+- [react-state-custom](https://github.com/vothanhdat/react-state-custom) - Turn any React hook into global state. Pure, performant, zero boilerplate.
 
 #### React Styling
 


### PR DESCRIPTION
Hello! I'd like to propose adding `react-state-custom` to the **React State Management and Data Fetching** section.

It is a lightweight (~10KB), TypeScript-first library that turns standard React hooks into global state without boilerplate, reducers, or providers.

**Proposed Entry:**
- [react-state-custom](https://github.com/vothanhdat/react-state-custom) - Turn any React hook into global state. Pure, performant, zero boilerplate.

Thank you for maintaining this awesome list!