### PR TITLE
docs: add lucide-react to React Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-email](https://github.com/resend/react-email) - Unstyled components for creating beautiful emails
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
+- [lucide-react](https://github.com/lucide-icons/lucide) - Beautiful & consistent open-source icon library for React.
 
 #### React State Management and Data Fetching
 


### PR DESCRIPTION
Added lucide-react to the React Component Libraries section.

GitHub: https://github.com/lucide-icons/lucide
Description: Beautiful, consistent open-source icon library for React.
Lucide is widely used across modern React apps as a lightweight, customizable icon set.

This improves the list by including an important, popular icon library.
