### PR TITLE
Fix typos in react internationalization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [formatjs](https://github.com/formatjs/formatjs) - Internationalize your web apps
 - [react-i18next](https://github.com/i18next/react-i18next) - Internationalization for React done right
-- [react-inltayer](https://github.com/aymericzip/intlayer) - Internationalization focused on maintenability for React
+- [react-intlayer](https://github.com/aymericzip/intlayer) - Internationalization focused on maintainability for React
 
 #### React Graphics and Animations
 


### PR DESCRIPTION
## Summary
I noticed a spelling error in a library name and a typo in a description within the **React Internationalization** section.

## Changes
- Corrected `react-inltayer` to **`react-intlayer`**.
- Corrected `maintenability` to **`maintainability`**.

Thanks!