### PR TITLE
Add BoldKit - Neubrutalism React component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A collection of awesome things regarding the React ecosystem.
 - [ariakit](https://github.com/ariakit/ariakit) - Toolkit for building accessible web apps with React
 - [react-email](https://github.com/resend/react-email) - Unstyled components for creating beautiful emails
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
+- [boldkit](https://github.com/ANIBIT14/boldkit) - Neubrutalism React components built on shadcn/ui with Radix UI and Tailwind CSS
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
 


### PR DESCRIPTION
## Add BoldKit

[BoldKit](https://boldkit.dev) is a free, open-source React component library featuring neubrutalism design aesthetics.

### Details

- **Repository:** https://github.com/ANIBIT14/boldkit
- **Website:** https://boldkit.dev
- **Components:** 45 UI components + 30 SVG shapes
- **Install via shadcn CLI:** `npx shadcn@latest add https://boldkit.dev/r/button.json`

### Built With
- React 19
- Tailwind CSS v4
- Radix UI primitives (fully accessible)
- TypeScript
- shadcn/ui compatible registry

### Why Add This?
BoldKit fills a gap for developers looking for neubrutalism-styled components. It follows the same architecture as shadcn/ui, making it familiar and easy to adopt. The library is MIT licensed and actively maintained.

### Placement
Added after `8bitcn-ui` in the React Component Libraries section, as both are themed component libraries built on shadcn/ui.