### PR TITLE
Add veritas-kanban to React Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ A collection of awesome things regarding the React ecosystem.
 - [overreacted](https://github.com/gaearon/overreacted.io) - Personal blog by Dan Abramov
 - [wave](https://github.com/wavetermdev/waveterm) - An open-source, cross-platform terminal for seamless workflows
 - [readest](https://github.com/readest/readest) - A minimalistic, feature-rich and cross-platform eBook reader
+- [veritas-kanban](https://github.com/BradGroux/veritas-kanban) - Self-hosted Kanban board with AI agent integration, built with React 19, Vite 6, and TanStack Query
 - [bookcars](https://github.com/aelassas/bookcars) - Car rental platform
 - [notifuse](https://github.com/Notifuse/notifuse) - Modern self-hosted emailing platform to send newsletters & transactional emails
 


### PR DESCRIPTION
## veritas-kanban

**Repository:** https://github.com/BradGroux/veritas-kanban

Self-hosted Kanban board with AI agent integration, built with React 19, Vite 6, and TanStack Query.

### Why it belongs in React Real Apps

- **React 19** with TypeScript strict mode
- **Vite 6** with vendor chunk splitting (69% bundle reduction)
- **TanStack Query** with WebSocket-aware polling
- **dnd-kit** for drag-and-drop with custom collision detection
- **Shadcn UI** components throughout
- **1,255 tests** (Vitest + Playwright E2E)
- Lazy-loaded settings tabs with Suspense + per-tab error boundaries
- Custom React.memo comparison on task cards to avoid re-renders from React Query refetches
- Debounced auto-save with optimistic updates

### Community traction

- Currently top post on r/reactjs
- 67+ GitHub stars within 24 hours of release
- Active community engagement via GitHub Issues and Discussions

This is a real, production-quality React application — not a tutorial or starter kit.