### PR TITLE
Add react-debugger to React Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A collection of awesome things regarding the React ecosystem.
 - [reactotron](https://github.com/skellock/reactotron) - A desktop app for inspecting your React and React Native projects
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) - React specific linting rules for ESLint
 - [why-did-you-render](https://github.com/welldone-software/why-did-you-render) - Monkey patches React to notify you about avoidable re-renders
+- [react-debugger](https://github.com/hoainho/react-debugger-extension) - Chrome DevTools extension for debugging React with performance profiling and memory leak detection
 
 #### React Libraries
 


### PR DESCRIPTION
Add [react-debugger](https://github.com/hoainho/react-debugger-extension) — a Chrome DevTools extension for debugging React with performance profiling and memory leak detection.

Checklist
- [x] The link is not a duplicate
- [x] The link is not a affiliate link
- [x] The project is open source (MIT License)
- [x] The project is actively maintained