### PR TITLE
Add ink-web to React Renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [react-three-fiber](https://github.com/pmndrs/react-three-fiber) - A React renderer for Three.js
 - [ink](https://github.com/vadimdemedes/ink) - React for interactive command-line apps
+- [ink-web](https://github.com/cjroth/ink-web) - Browser-based runtime for Ink that renders React TUI apps in xterm.js
 - [remotion](https://github.com/remotion-dev/remotion) - Make videos programmatically with React
 - [react-pdf](https://github.com/diegomura/react-pdf) - Create PDF files using React
 - [react-figma](https://github.com/react-figma/react-figma) - A React renderer for Figma


### PR DESCRIPTION
## Summary

[ink-web](https://github.com/cjroth/ink-web) extends the [Ink](https://github.com/vadimdemedes/ink) renderer (already listed in React Renderers) to the browser. It is a React renderer that brings terminal UI apps to the web via [xterm.js](https://xtermjs.org/).

- Free and open source
- Renders React TUI apps in the browser using xterm.js
- Complements the existing Ink entry by enabling Ink apps to run on the web

Docs: [ink-web.dev](https://ink-web.dev)

## Checklist

- [x] Entry follows the existing format
- [x] Placed directly after the related ink entry in React Renderers
- [x] Links to a GitHub repository
- [x] Project is free and open source