### PR TITLE
Add witqq-spreadsheet to React Tables and Grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) - A draggable and resizable grid layout with responsive breakpoints
 - [tanstack-table](https://github.com/TanStack/table) - Headless UI for building powerful tables & datagrids
 - [react-data-grid](https://github.com/adazzle/react-data-grid) - Feature-rich and customizable data grid React component
+- [witqq-spreadsheet](https://github.com/witqq/spreadsheet) - Canvas-based spreadsheet engine with zero dependencies, 100K+ rows at 60fps
 
 #### React Maps
 


### PR DESCRIPTION
**[witqq-spreadsheet](https://github.com/witqq/spreadsheet)** — Canvas-based spreadsheet engine with zero dependencies, 100K+ rows at 60fps.

### Why it's awesome
- Renders **100K+ rows at 60fps** using Canvas 2D with zero external dependencies
- React wrapper with typed callbacks, ref API, and prop updates
- Full spreadsheet features: sorting, filtering, formulas, clipboard, undo/redo, cell merge, frozen panes
- Real-time collaboration via OT engine with WebSocket relay
- TypeScript strict mode, ~36KB gzipped widget bundle

### Links
- [GitHub](https://github.com/witqq/spreadsheet)
- [Live Demo](https://spreadsheet.witqq.dev/)
- [npm](https://www.npmjs.com/package/@witqq/spreadsheet)

Added to **React Tables and Grids** section, alphabetically.