### PR TITLE
Add theSVG - brand SVG icon library

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-uploady](https://github.com/rpldy/react-uploady) - Modern file-upload components & hooks for React
 - [downshift](https://github.com/downshift-js/downshift) - React autocomplete, combobox or select dropdown components
 - [react-error-boundary](https://github.com/bvaughn/react-error-boundary) - A React error boundary component that lets you catch errors
+- [thesvg](https://github.com/GLINCKER/thesvg) - 4,000+ brand SVG logos with React components, CDN, and REST API (npm i thesvg / @thesvg/react)
 
 #### React Testing
 


### PR DESCRIPTION
Adding [theSVG](https://github.com/GLINCKER/thesvg) - a library of 4,000+ brand SVG logos.

Features:
- 4,000+ brand icons with multiple color variants
- Simple install: npm i thesvg
- React components, CDN, and REST API access
- CLI tool for downloading icons
- MIT licensed

Website: https://thesvg.org
npm: https://www.npmjs.com/package/thesvg