### PR TITLE
Add @form2js/react to form libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form) - A React component for building Web forms from JSON Schema
 - [formily](https://github.com/alibaba/formily) - Alibaba Group Unified Form Solution
 - [tanstack-form](https://github.com/TanStack/form) - Headless, performant, and type-safe form state management
-- [@form2js/react](https://github.com/maxatwork/form2js/tree/main/packages/react) - Small React hook for parsing form submissions with optional schema validation and async submit state
+- [@form2js/react](https://github.com/maxatwork/form2js/tree/master/packages/react) - Small React hook for parsing form submissions with optional schema validation and async submit state
 
 #### React Tables and Grids
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form) - A React component for building Web forms from JSON Schema
 - [formily](https://github.com/alibaba/formily) - Alibaba Group Unified Form Solution
 - [tanstack-form](https://github.com/TanStack/form) - Headless, performant, and type-safe form state management
+- [@form2js/react](https://github.com/maxatwork/form2js/tree/main/packages/react) - Small React hook for parsing form submissions with optional schema validation and async submit state
 
 #### React Tables and Grids
 


### PR DESCRIPTION
## Summary

Add [@form2js/react](https://github.com/maxatwork/form2js/tree/master/packages/react) to the React Forms section.

`@form2js/react` is a small MIT-licensed React hook for handling native form submissions, parsing them into nested objects, optionally validating with a schema, and exposing async submit state.

It fits the React Forms category as a focused form-handling library for React, and the project is fully free/open source.