### PR TITLE
Add MapMetrics GL to React Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [react-map-gl](https://github.com/visgl/react-map-gl) - React friendly API wrapper around MapboxGL JS
 - [react-leaflet](https://github.com/PaulLeCam/react-leaflet) - React components for Leaflet maps
+- [mapmetrics-gl](https://github.com/MapMetrics/mapmetrics-gl) - Mapbox GL JS-compatible mapping library with built-in tiles, geocoding, routing, and search
 
 #### React Charts
 


### PR DESCRIPTION
Adding MapMetrics GL to the React Maps section.

MapMetrics GL is a Mapbox GL JS-compatible mapping library with built-in support for map tiles, geocoding, routing, and search. EU-hosted, GDPR compliant.

GitHub: https://github.com/MapMetrics/mapmetrics-gl
Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V.