### PR TITLE
Add pushduck to React Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A collection of awesome things regarding the React ecosystem.
 - [floating-ui](https://github.com/floating-ui/floating-ui) - Toolkit to create floating elements
 - [loadable-components](https://github.com/gregberge/loadable-components) - The recommended Code Splitting library for React
 - [react-uploady](https://github.com/rpldy/react-uploady) - Modern file-upload components & hooks for React
+- [pushduck](https://github.com/abhay-ramesh/pushduck) - Type-safe S3 file uploads with React hooks, presigned URLs, and edge runtime support
 - [downshift](https://github.com/downshift-js/downshift) - React autocomplete, combobox or select dropdown components
 - [react-error-boundary](https://github.com/bvaughn/react-error-boundary) - A React error boundary component that lets you catch errors
 


### PR DESCRIPTION
Adding [pushduck](https://github.com/abhay-ramesh/pushduck) to the React Libraries section.

Pushduck provides React hooks for type-safe S3 file uploads. It generates presigned URLs server-side so files upload directly from the browser to S3-compatible storage (AWS S3, Cloudflare R2, DigitalOcean Spaces, MinIO) — no server bandwidth used. Works on Cloudflare Workers and Vercel Edge. MIT licensed.

- GitHub: https://github.com/abhay-ramesh/pushduck
- npm: https://www.npmjs.com/package/pushduck