### PR TITLE
Add shieldcn to React Renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-pdf](https://github.com/diegomura/react-pdf) - Create PDF files using React
 - [react-figma](https://github.com/react-figma/react-figma) - A React renderer for Figma
 - [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) - A very fast and versatile markdown toolchain
+- [shieldcn](https://github.com/jal-co/shieldcn) - Renders shadcn/ui Button components to SVG badge images via Satori
 
 #### React Internationalization
 


### PR DESCRIPTION
[shieldcn](https://github.com/jal-co/shieldcn) renders React components (shadcn/ui Buttons) to SVG badge images via [Satori](https://github.com/vercel/satori). It's a shields.io alternative where every badge is a React component rendered to SVG — a unique use case of React as a renderer for static image generation.

**Website:** https://shieldcn.dev

Built with React 19, Next.js 16, and Satori. Supports npm, GitHub, Discord, Reddit badges with dark/light mode, multiple variants, and 40,000+ icons.

Added to the **React Renderers** section alongside react-pdf, remotion, and react-figma — all projects that use React to render non-DOM output formats.