### PR TITLE
Add User Tour Kit to React Awesome Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A collection of awesome things regarding the React ecosystem.
 - [tagify](https://github.com/yairEO/tagify) - Lightweight, efficient Tags input component
 - [puck](https://github.com/measuredco/puck) - The visual editor for React
 - [json-edit-react](https://github.com/CarlosNZ/json-edit-react) - Highly configurable JSON/Object tree editor/viewer
+- [User Tour Kit](https://github.com/domidex01/tour-kit) - Headless onboarding library for product tours, hints, checklists, microsurveys, and announcements. shadcn/ui-friendly, WCAG 2.1 AA, TypeScript-first.
 
 #### React Components Sandboxes
 


### PR DESCRIPTION
Adding [User Tour Kit](https://github.com/domidex01/tour-kit) to the React Awesome Components section.

User Tour Kit is a headless onboarding library — modular packages for tours, hints, checklists, surveys, announcements, adoption tracking, and analytics. The core, React, and hints packages are MIT-licensed; commercial packages are available via the `@tour-kit/*` scope. Integrates cleanly with shadcn/ui, Radix UI, and Tailwind CSS.

Repo: https://github.com/domidex01/tour-kit
Docs: https://usertourkit.com
