### PR TITLE
Add 30tools to React Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ A collection of awesome things regarding the React ecosystem.
 - [fulcro](https://github.com/fulcrologic/fulcro) - A library for development of web applications in clj/cljs
 
 #### React Real Apps
+- [30tools](https://github.com/SH20RAJ/30tools) - 660+ free browser-based online tools built with React and Next.js
 
 - [mattermost-server](https://github.com/mattermost/mattermost-server) - An open source platform for secure collaboration
 - [kibana](https://github.com/elastic/kibana) - Your window into the Elastic Stack


### PR DESCRIPTION
Adding [30tools](https://github.com/SH20RAJ/30tools) — a production React app with 660+ free online utilities.

- **Live:** https://30tools.com
- **Stack:** React + Next.js 15 App Router
- **Scale:** 871 statically generated pages, 200+ React components
- **Privacy-first:** All tools run 100% client-side using browser APIs (Canvas, Web Audio, pdf-lib, crypto)
- **Categories:** PDF, image, video, text, developer, SEO, converters, calculators, generators