### PR TITLE
Add varg (JSX-based AI video SDK) to React Renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-three-fiber](https://github.com/pmndrs/react-three-fiber) - A React renderer for Three.js
 - [ink](https://github.com/vadimdemedes/ink) - React for interactive command-line apps
 - [remotion](https://github.com/remotion-dev/remotion) - Make videos programmatically with React
+- [varg](https://github.com/vargHQ/sdk) - Generate AI videos with JSX. Compose AI-generated clips, music, captions, lipsync across 40+ providers (Kling, Sora, Flux, ElevenLabs).
 - [react-pdf](https://github.com/diegomura/react-pdf) - Create PDF files using React
 - [react-figma](https://github.com/react-figma/react-figma) - A React renderer for Figma
 - [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) - A very fast and versatile markdown toolchain


### PR DESCRIPTION
Adding varg, an open-source TypeScript SDK that uses JSX/React patterns for AI video composition. Sits naturally next to remotion in the React Renderers section.

Repo: https://github.com/vargHQ/sdk
License: Apache-2.0