### PR TITLE
Add Mandu — agent-native fullstack framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-admin](https://github.com/marmelab/react-admin) - A frontend Framework for building B2B applications
 - [refine](https://github.com/refinedev/refine) - Build your React-based CRUD applications, without constraints
 - [vike](https://github.com/vikejs/vike) - The Modular Framework - Next.js & Nuxt alternative
+- [mandu](https://github.com/konamgil/mandu) - Agent-native fullstack framework on Bun + React. File-system routes, runtime architecture guard, contract-first APIs, and 100+ MCP tools so AI editors can drive the project end-to-end
 
 #### React Component Libraries
 


### PR DESCRIPTION
Adds [Mandu](https://github.com/konamgil/mandu) under **React → React Frameworks**, alongside Next, Remix, Gatsby, Refine, and Vike.

Mandu is a Bun-native, agent-native fullstack framework on top of React:

- File-system routing under `app/**/page.tsx`, with `.island.tsx` for client hydration
- Runtime architecture **Guard** that rejects layer/import violations as the dev server runs (no waiting for lint)
- **Contract-first APIs** — `Mandu.contract({...})` declares zod request/response schemas once and auto-derives TS types, validation, and OpenAPI
- 100+ MCP tools so AI editors (Claude Code, Cursor, OpenAI Codex, GitHub Copilot) can scaffold routes, run guard checks, generate tests, and deploy without leaving the chat
- Static export, SSR, edge adapters (CF Workers, Vercel Edge, Deno Deploy, Netlify Edge), and a CLI that emits platform-specific deploy configs

Site / docs: https://mandujs.com  ·  source: https://github.com/konamgil/mandu

Happy to revise the description if it should be tighter to match neighbouring entries.