### PR TITLE
docs: add reactuse to React Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-uploady](https://github.com/rpldy/react-uploady) - Modern file-upload components & hooks for React
 - [downshift](https://github.com/downshift-js/downshift) - React autocomplete, combobox or select dropdown components
 - [react-error-boundary](https://github.com/bvaughn/react-error-boundary) - A React error boundary component that lets you catch errors
+- [reactuse](https://github.com/childrentime/reactuse) - Collection of 110+ tree-shakable, SSR-safe, TypeScript-first React Hooks
 
 #### React Testing
 


### PR DESCRIPTION
Adds [reactuse](https://github.com/childrentime/reactuse) — a collection of 110+ tree-shakable, SSR-safe, TypeScript-first React Hooks (browser, state, effect, element, integrations) — to the **React Libraries** section.

- **GitHub:** https://github.com/childrentime/reactuse (970+ stars, actively maintained)
- **Website:** https://reactuse.com
- **npm:** https://www.npmjs.com/package/@reactuses/core

Hook libraries already present in the list (`react-uploady`) make this a fitting section. Inspired by VueUse for the React ecosystem.