### PR TITLE
Add enclave to React Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ A collection of awesome things regarding the React ecosystem.
 - [readest](https://github.com/readest/readest) - A minimalistic, feature-rich and cross-platform eBook reader
 - [bookcars](https://github.com/aelassas/bookcars) - Car rental platform
 - [notifuse](https://github.com/Notifuse/notifuse) - Modern self-hosted emailing platform to send newsletters & transactional emails
+- [enclave](https://github.com/yuanzui0728/enclave) - Self-hosted, open-source AI virtual social network (Character.AI / Replika alternative). React + Vite frontend, NestJS backend, Tauri desktop shell
 
 ### React Native
 


### PR DESCRIPTION
This PR adds [enclave](https://github.com/yuanzui0728/enclave) to **React Real Apps**.

Enclave is an open-source, self-hosted AI virtual social network — a Character.AI / Replika alternative. Frontend is built with **React + Vite**, with a Tauri desktop shell that wraps the same React app.

- License: MIT
- Frontend: React 19 + Vite + TypeScript + Zustand
- Live demo: https://www.enclave.top/