### PR TITLE
Add json-to-ts to React Forms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form) - A React component for building Web forms from JSON Schema
 - [formily](https://github.com/alibaba/formily) - Alibaba Group Unified Form Solution
 - [tanstack-form](https://github.com/TanStack/form) - Headless, performant, and type-safe form state management
+- [json-to-ts](https://json-to-ts-app.netlify.app/) - Free hosted converter that turns a JSON sample (e.g. an API response) into a Zod or Valibot schema for use as a `react-hook-form` resolver
 
 #### React Tables and Grids
 


### PR DESCRIPTION
Adds [json-to-ts](https://json-to-ts-app.netlify.app/) to the **React Forms** section, immediately after `tanstack-form`.

## What it is

A free, hosted, in-browser converter that turns a pasted JSON sample (typically an API response) into a Zod or Valibot schema, ready to drop into `react-hook-form` via `@hookform/resolvers/zod` or `/valibot`.

Source: [SolvoHQ/json-to-ts](https://github.com/SolvoHQ/json-to-ts) (MIT). Runs entirely client-side, no signup.

## Why it fits this section

The section already includes `react-jsonschema-form`, which similarly bridges a data-shape definition into form behaviour. `react-hook-form` (the section's first entry) is the most common React form library, and Zod/Valibot are its two most popular validation resolvers — most React form work today starts with "I have an API response, what's the schema?". This tool removes that step.

## Format

Followed the `[name](url) - description` convention used by the other entries in this section (one line, no period, sentence-case).