### PR TITLE
Add srb-ui to React Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A collection of awesome things regarding the React ecosystem.
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
+- [srb-ui](https://github.com/sourabhs701/srb.codes) - Production-ready UI blocks and components built on shadcn/ui with Tailwind CSS and Framer Motion animations.
 
 #### React State Management and Data Fetching
 


### PR DESCRIPTION
## Add srb-ui

Adding **srb/ui** (https://ui.srb.codes) to the React Component Libraries section.

- GitHub: https://github.com/sourabhs701/srb.codes
- Built on shadcn/ui + Radix UI with Framer Motion animations
- Copy-paste component model, production-ready blocks (hero, CTA, features, testimonials)
- Actively maintained with new components added regularly

Entry added at the end of the React Component Libraries section.