### PR TITLE
Add ethora-chat-component to React Awesome Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A collection of awesome things regarding the React ecosystem.
 - [tagify](https://github.com/yairEO/tagify) - Lightweight, efficient Tags input component
 - [puck](https://github.com/measuredco/puck) - The visual editor for React
 - [json-edit-react](https://github.com/CarlosNZ/json-edit-react) - Highly configurable JSON/Object tree editor/viewer
+- [ethora-chat-component](https://github.com/dappros/ethora-chat-component) - Embeddable chat UI — popup widget, embedded panel, or standalone app
 
 #### React Components Sandboxes
 


### PR DESCRIPTION
Adds [`ethora-chat-component`](https://github.com/dappros/ethora-chat-component) under **React Awesome Components**.

It's the official React/TypeScript chat UI for [Ethora](https://github.com/dappros/ethora), the open-source chat & messaging platform — install from npm and render a full chat interface as a popup widget, an embedded panel, or a standalone app.

- npm: [`@ethora/chat-component`](https://www.npmjs.com/package/@ethora/chat-component)
- Live demo: https://playground.chat.ethora.com
- MIT licensed, actively maintained, TypeScript + Tailwind.