### PR TITLE
Add @ethora/chat-component-rn (React Native chat UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) - Customizable Icons for React Native
 - [react-native-gifted-chat](https://github.com/FaridSafi/react-native-gifted-chat) - The most complete chat UI for React Native
+- [@ethora/chat-component-rn](https://github.com/dappros/ethora-chat-component-rn) - Drop-in XMPP chat component for React Native / Expo, by Ethora.
 
 #### React Native Libraries
 


### PR DESCRIPTION
Adds [`@ethora/chat-component-rn`](https://github.com/dappros/ethora-chat-component-rn) under **React Native Awesome Components**, alongside the only existing chat entry (`react-native-gifted-chat`).

It's the React Native counterpart to [`@ethora/chat-component`](https://github.com/dappros/ethora-chat-component) (already listed under **React Awesome Components** via PR [#1718](https://github.com/enaqx/awesome-react/pull/1718)). Same Ethora chat & messaging platform, different runtime.

- npm: [`@ethora/chat-component-rn`](https://www.npmjs.com/package/@ethora/chat-component-rn) (published 2026-05-15)
- MIT