### PR TITLE
Add react-debugger to React Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A collection of awesome things regarding the React ecosystem.
 - [reactotron](https://github.com/skellock/reactotron) - A desktop app for inspecting your React and React Native projects
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) - React specific linting rules for ESLint
 - [why-did-you-render](https://github.com/welldone-software/why-did-you-render) - Monkey patches React to notify you about avoidable re-renders
+- [react-debugger](https://github.com/hoainho/react-debugger-extension) - Chrome DevTools extension for debugging React with performance profiling and memory leak detection
 
 #### React Libraries
 


### PR DESCRIPTION
Adds [react-debugger](https://github.com/hoainho/react-debugger-extension) to the **React Development Tools** section, alongside `why-did-you-render` and `reactotron`.

## What it is

A Chrome DevTools panel that combines Timeline, Performance, Memory, Side Effects, Redux, CLS, and AI-powered analysis in a single tab. The goal is to stop developers from juggling React DevTools + Chrome Performance + Redux DevTools + Memory tab for a single bug — one panel, seven analyzers, plus an optional AI layer.

## Why it fits

- **Active and maintained.** v2.0.3 shipped Feb 2026 with a major performance overhaul (sub-2ms-per-commit budget, hybrid render snapshot architecture aligned with [bippy](https://github.com/AidenBai/bippy)).
- **MIT licensed.**
- **Demo and screenshots in the README.**
- Same shelf as `why-did-you-render` and `reactotron` already on this list — same problem space (React debugging), different angle (visual DevTools panel + multi-domain analysis).

## Diff
One line addition under `#### React Development Tools`:
```
+ [react-debugger](https://github.com/hoainho/react-debugger-extension) - Chrome DevTools extension for debugging React with performance profiling and memory leak detection
```

Thanks for maintaining the list!
