### PR TITLE
Add client-creep — CLI to trace why Next.js components are client components

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A collection of awesome things regarding the React ecosystem.
 - [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) - React specific linting rules for ESLint
 - [react-scan](https://github.com/aidenybai/react-scan) - Scan for React performance issues and eliminate slow renders in your app
 - [why-did-you-render](https://github.com/welldone-software/why-did-you-render) - Monkey patches React to notify you about avoidable re-renders
+- [client-creep](https://github.com/DhruvilChauahan0210/client-creep) - CLI that traces why Next.js components are client components, detects accidental creep, and estimates bundle cost
 
 #### React Libraries
 


### PR DESCRIPTION
## What is client-creep?

[client-creep](https://github.com/DhruvilChauahan0210/client-creep) is a zero-setup CLI that statically analyzes any Next.js App Router project and answers three questions no existing tool answers together:

1. **Why is this a client component?** — full import chain trace to the `"use client"` boundary
2. **Did it need to be?** — flags components with no hooks/browser APIs (accidental creep)
3. **What does it cost?** — estimated KB per boundary + total recoverable

\`\`\`bash
npx client-creep
\`\`\`

Fits naturally alongside `react-scan` and `why-did-you-render` in the React Development Tools section — same audience, complementary problem (bundle size / RSC boundary analysis vs render performance).

- Works on **Next.js 13, 14, 15, and 16**
- Zero config, purely static — no app running required
- Supports `--html` (interactive D3 graph), `--watch`, `--ci`, `--budget`, and monorepo workspaces

Tested on the dub.co codebase: 1,073 client components, 643 KB potentially recoverable.

npm: https://www.npmjs.com/package/client-creep