### PR TITLE
Add otfdashkit-ui to React Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A collection of awesome things regarding the React ecosystem.
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
+- [otfdashkit-ui](https://github.com/otf-kit/sdk) - Cross-platform component library — same API on React web (Radix + Tailwind) and React Native (Expo). MIT.
 
 #### React State Management and Data Fetching
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A collection of awesome things regarding the React ecosystem.
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
 - [otfdashkit-ui](https://github.com/otf-kit/sdk) - Cross-platform component library — same API on React web (Radix + Tailwind) and React Native (Expo). MIT.
+- [otfdashkit-ui](https://github.com/otf-kit/sdk) - Cross-platform component library — same API on React web (Radix + Tailwind) and React Native (Expo). MIT.
 
 #### React State Management and Data Fetching
 


### PR DESCRIPTION
Adds [otfdashkit-ui](https://github.com/otf-kit/sdk) to the React Component Libraries section.

**Why it fits:** The only entry in this section that works identically on both React web and React Native — same component name, same props, same visual output. Radix + Tailwind for web; Tamagui for native. Free MIT SDK.

- GitHub: https://github.com/otf-kit/sdk
- npm: `@otfdashkit/ui` (web) + `@otfdashkit/ui-native` (native)
- Live components: https://otf-kit.dev/components