### PR TITLE
Add NextBlock CMS to React frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A collection of awesome things regarding the React ecosystem.
 #### React Frameworks
 
 - [next](https://github.com/vercel/next.js) - The React Framework
+- [NextBlock CMS](https://nextblock.dev) - A unified full-stack CMS framework built on Next.js 16 and Supabase with AI-native features and e-commerce available.
 - [gatsby](https://github.com/gatsbyjs/gatsby) - Build modern websites with React
 - [remix](https://github.com/remix-run/remix) - Full-stack web Framework that lets you focus on the user interface
 - [react-admin](https://github.com/marmelab/react-admin) - A frontend Framework for building B2B applications


### PR DESCRIPTION
Hi! I'd like to suggest adding NextBlock CMS to the React Frameworks list.

- Name: NextBlock CMS
- Website: https://nextblock.dev
- Description: A unified full-stack CMS framework built on Next.js 16 and Supabase, featuring a visual block editor and AI orchestration.

I have verified that:
- [x] The entry is in alphabetical order within the React Frameworks section.
- [x] The description is concise.
- [x] This is a modern framework aligned with the React ecosystem.

Thank you for maintaining this collection!