### PR TITLE
docs: add cate to React Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ A collection of awesome things regarding the React ecosystem.
 - [readest](https://github.com/readest/readest) - A minimalistic, feature-rich and cross-platform eBook reader
 - [bookcars](https://github.com/aelassas/bookcars) - Car rental platform
 - [notifuse](https://github.com/Notifuse/notifuse) - Modern self-hosted emailing platform to send newsletters & transactional emails
+- [cate](https://github.com/0-AI-UG/cate) - An open source IDE on an infinite zoomable canvas, with editor, terminal, and browser panels
 
 ### React Native
 


### PR DESCRIPTION
Adds Cate to React Real Apps. It is an open source, MIT licensed, cross-platform desktop IDE built with React, TypeScript, and Electron (1.3k stars, actively developed). Editor, terminal, browser, and AI agent panels are arranged on an infinite zoomable canvas instead of tabs. Similar in profile to wave and readest already in this section.
