### PR TITLE
Add MDMA to React Renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-pdf](https://github.com/diegomura/react-pdf) - Create PDF files using React
 - [react-figma](https://github.com/react-figma/react-figma) - A React renderer for Figma
 - [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) - A very fast and versatile markdown toolchain
+- [MDMA](https://github.com/MobileReality/mdma) - Render LLM-generated interactive Markdown (forms, tables, approval gates, charts) as React components
 
 #### React Internationalization
 


### PR DESCRIPTION
Adds [MDMA](https://github.com/MobileReality/mdma) to the *React Renderers* subsection.

MDMA (Markdown Document with Mounted Applications) renders LLM-generated interactive Markdown — forms, tables, approval gates, charts, callouts, webhooks — as React components. `@mobile-reality/mdma-renderer-react` provides a `MdmaDocument` component plus `useComponentState`/`useBinding` hooks for all 9 component types, fitting alongside react-pdf, react-figma, and ink as a renderer for a specific target.

- Repo: https://github.com/MobileReality/mdma
- npm: https://www.npmjs.com/package/@mobile-reality/mdma-renderer-react
- License: MIT

Entry follows the subsection format.