### PR TITLE
Add Markstream to React Renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-pdf](https://github.com/diegomura/react-pdf) - Create PDF files using React
 - [react-figma](https://github.com/react-figma/react-figma) - A React renderer for Figma
 - [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) - A very fast and versatile markdown toolchain
+- [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for React and AI chat interfaces
 
 #### React Internationalization
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-pdf](https://github.com/diegomura/react-pdf) - Create PDF files using React
 - [react-figma](https://github.com/react-figma/react-figma) - A React renderer for Figma
 - [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) - A very fast and versatile markdown toolchain
-- [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for React and AI chat interfaces
+- [markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for React and AI chat interfaces
 
 #### React Internationalization
 


### PR DESCRIPTION
## Summary

Adds Markstream to the React Renderers section. Markstream provides a React package for progressively rendering incomplete Markdown in AI chat interfaces, with support for Mermaid, KaTeX, syntax highlighting, and SSR.

## Disclosure

I am the maintainer of Markstream. Thank you for considering this addition.