### PR TITLE
Add blok to React Awesome Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A collection of awesome things regarding the React ecosystem.
 - [tagify](https://github.com/yairEO/tagify) - Lightweight, efficient Tags input component
 - [puck](https://github.com/puckeditor/puck) - The visual editor for React
 - [json-edit-react](https://github.com/CarlosNZ/json-edit-react) - Highly configurable JSON/Object tree editor/viewer
+- [blok](https://github.com/JackUait/blok) - Headless block-based rich text editor that outputs JSON instead of HTML
 
 #### React Components Sandboxes
 


### PR DESCRIPTION
Adds [blok](https://github.com/JackUait/blok) to React Awesome Components.

Blok is a headless, block-based rich text editor (Notion-style) that outputs JSON blocks instead of HTML. It ships a first-party React adapter (`@bloklabs/react`), so it sits naturally next to `puck` and `json-edit-react` in this section.

- Repo: https://github.com/JackUait/blok
- Docs: https://blokeditor.com
- Demo: https://blokeditor.com/demo

Free and open source (Apache-2.0), no paid tiers or hosted upsell.