### PR TITLE
Add jsonschema-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A collection of awesome things regarding the React ecosystem.
 
 - [react-hook-form](https://github.com/react-hook-form/react-hook-form) - React Hooks for form state management and validation
 - [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form) - A React component for building Web forms from JSON Schema
+- [jsonschema-editor](https://github.com/eumicro/jsonschema-editor) - JSON Schema and UI Schema form editor for React, with fillable forms, nested structures, and oneOf type selection
 - [formily](https://github.com/alibaba/formily) - Alibaba Group Unified Form Solution
 - [tanstack-form](https://github.com/TanStack/form) - Headless, performant, and type-safe form state management
 


### PR DESCRIPTION
﻿Adds [jsonschema-editor](https://github.com/eumicro/jsonschema-editor) under React Forms, next to react-jsonschema-form.

Open-source MIT monorepo: JSON Schema + UI Schema form editor / fillable forms for React 19 (`@jsonschema-editor/react`), also Vue 3. Active maintenance, English README with demo GIF and CONTRIBUTING.
