### PR TITLE
Add usva to React Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A collection of awesome things regarding the React ecosystem.
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
+- [usva](https://github.com/matt-pasek/usva) - A design language in three themes and the React component library that speaks it, installable from npm or copyable from its own registry
 
 #### React State Management and Data Fetching
 


### PR DESCRIPTION
Adds usva to React Component Libraries.

usva is a design language in three themes built over one vocabulary of 24 semantic role tokens. The themes differ in colour, density and timing rather than palette alone, and `data-theme` scopes to any element, so a subtree can run a different theme from the page around it.

Every component ships two ways from the same source: installed from npm as `@usva-ui/react`, or copied in as source from its own shadcn-compatible registry. CI asserts the two paths are byte-identical.

Free to use, commercially included, and you can fork it or copy a component out of the registry and own it outright. MIT with the Commons Clause, so the only restriction is on reselling the components themselves as the product.

Repo: https://github.com/matt-pasek/usva · Docs: https://usva.build/docs/get-started
