### PR TITLE
Add map-chart to React Charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-vis](https://github.com/uber/react-vis) - Data Visualization Components
 - [nivo](https://github.com/plouc/nivo) - Provides a rich set of data visualization components built on top of the D3 and React libraries
 - [xyflow](https://github.com/xyflow/xyflow) - A customizable React component for building node-based editors and interactive diagrams
-- [map-chart](https://github.com/noeGnh/map-chart) - React and Vue 3 components for displaying dynamic data on a world, continents, countries and custom maps.
+- [map-chart](https://github.com/noeGnh/map-chart) - React and Vue 3 components for displaying dynamic data on a world, continents, countries and custom maps
 
 #### React Renderers
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-vis](https://github.com/uber/react-vis) - Data Visualization Components
 - [nivo](https://github.com/plouc/nivo) - Provides a rich set of data visualization components built on top of the D3 and React libraries
 - [xyflow](https://github.com/xyflow/xyflow) - A customizable React component for building node-based editors and interactive diagrams
+- [map-chart](https://github.com/noeGnh/map-chart) - React and Vue 3 components for displaying dynamic data on a world, continents, countries and custom maps.
 
 #### React Renderers
 


### PR DESCRIPTION
Add [map-chart](https://github.com/noeGnh/map-chart), React and Vue 3 components for displaying dynamic data on a world, continents, countries and custom maps to the React Charts section.