### PR TITLE
Add microcharts to React Charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-vis](https://github.com/uber/react-vis) - Data Visualization Components
 - [nivo](https://github.com/plouc/nivo) - Provides a rich set of data visualization components built on top of the D3 and React libraries
 - [xyflow](https://github.com/xyflow/xyflow) - A customizable React component for building node-based editors and interactive diagrams
+- [microcharts](https://github.com/ganapativs/microcharts) - Word-sized charts that fit inline in text and table cells, with static and interactive versions
 
 #### React Renderers
 


### PR DESCRIPTION
Everything in that section right now is a full canvas charting library. microcharts covers the small stuff instead, charts sized to sit in a sentence or a table cell. 106 types, no dependencies.

Docs and gallery: https://microcharts.dev

I'm the author, so flagging that up front.