### PR TITLE
Add adapttable to React Tables and Grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) - A draggable and resizable grid layout with responsive breakpoints
 - [tanstack-table](https://github.com/TanStack/table) - Headless UI for building powerful tables & datagrids
 - [react-data-grid](https://github.com/Comcast/react-data-grid) - Feature-rich and customizable data grid React component
+- [adapttable](https://github.com/orwa-mahmoud/adapttable) - Headless data table with optional native adapters for eight UI kits
 
 #### React Maps
 


### PR DESCRIPTION
A headless `useDataTable` hook — prop-getters, no rendered markup — with optional adapter packages providing native table UI for Mantine, MUI, Chakra, Ant Design, Radix, Base UI, shadcn/Tailwind and plain HTML. MIT, TypeScript, React 18/19.

Already listed in awesome-react-headless-components, awesome-shadcn-ui and awesome-mantine.
