### PR TITLE
Add radianui to component library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A collection of awesome things regarding the React ecosystem.
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
+- [radianui](https://github.com/Radian-os/radianui) - Accessible React components built on Radix UI and Tailwind CSS, with CLI
 
 #### React State Management and Data Fetching
 


### PR DESCRIPTION
Adding radianui  an open-source React component library built with Radix UI and Tailwind CSS, offering CLI-based copy-paste component installation. Fits alongside shadcn-ui, 8bitcn-ui, and headlessui already in this section.