### PR TITLE
docs: add DSH Studio to React real apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ A collection of awesome things regarding the React ecosystem.
 - [readest](https://github.com/readest/readest) - A minimalistic, feature-rich and cross-platform eBook reader
 - [bookcars](https://github.com/aelassas/bookcars) - Car rental platform
 - [notifuse](https://github.com/Notifuse/notifuse) - Modern self-hosted emailing platform to send newsletters & transactional emails
+- [dsh-studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop application for installing and supervising DeepSeek Harness locally
 
 ### React Native
 


### PR DESCRIPTION
## Summary

Adds [DSH Studio](https://github.com/Moresyl/dsh-studio) to **React Real Apps**.

DSH Studio is a free, MIT-licensed cross-platform desktop application built with React, TypeScript, Vite, and Tauri. It installs and supervises DeepSeek Harness locally, exposing health state, logs, start/stop controls, and packaged releases through a desktop interface.

- **React stack:** React 19, TypeScript, Vite
- **Desktop shell:** Tauri 2
- **Platforms:** macOS (Apple Silicon and Intel), Windows, Linux
- **Release:** https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1

The change is one neutral entry in the existing list format. Disclosure: I maintain DSH Studio.