### PR TITLE
Add enum-plus to React Internationalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ A collection of awesome things regarding the React ecosystem.
 - [formatjs](https://github.com/formatjs/formatjs) - Internationalize your web apps
 - [react-i18next](https://github.com/i18next/react-i18next) - Internationalization for React done right
 - [react-intlayer](https://github.com/aymericzip/intlayer) - Internationalization focused on maintainability for React
+- [enum-plus](https://github.com/shijistar/enum-plus) - Render localized labels, badges and dropdown options for your business enums in React
 
 #### React Graphics and Animations
 


### PR DESCRIPTION
## What this is

Proposing [enum-plus](https://github.com/shijistar/enum-plus) for the **React Internationalization** section.

It's a drop-in replacement for the native TS enum that exposes your business enums as a data source with **localized labels/options**, via a series of React plugins `@enum-plus/plugin-react` and `@enum-plus/plugin-react-i18next`. It renders localized labels, badges and select options in React components, resolving keys through react-i18next / i18next. 0 runtime deps, MIT.

## Evidence of maintenance
- npm v3.3.0, 60 releases, 0 dependencies, built-in TS type declarations
- 2xx stars, 512 commits, active updates, vitest e2e + codecov coverage 100%
- Docs site: https://shijistar.github.io/enum-plus
