### PR TITLE
Add rab to React State Management and Data Fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A collection of awesome things regarding the React ecosystem.
 - [immer](https://github.com/immerjs/immer) - Create the next immutable state by mutating the current one
 - [immutable-js](https://github.com/immutable-js/immutable-js) - Immutable persistent data collections for JavaScript
 - [rxdb](https://github.com/pubkey/rxdb) - A fast, offline-first, reactive database for JavaScript Applications
+- [rab](https://github.com/ximing/rab) - AI-first reactive state architecture where UI, tests, and coding agents share one observable state surface
 
 #### React Styling
 


### PR DESCRIPTION
Adds [rab](https://github.com/ximing/rab) — an open-source, AI-first reactive state architecture for React.

- Packages: `@rabjs/observer`, `@rabjs/service`, `@rabjs/react` (observable Service instances, containers, lifecycle, loading/error method models)
- Humans, tests, DevTools, and coding agents all operate on the same observable state surface via named Service instances
- MIT licensed, actively maintained, with docs at https://ximing.github.io/rab/

Placed in the React State Management and Data Fetching section, one-line entry matching the existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)