### PR TITLE
Add xexcel to React Tables and Grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) - A draggable and resizable grid layout with responsive breakpoints
 - [tanstack-table](https://github.com/TanStack/table) - Headless UI for building powerful tables & datagrids
 - [react-data-grid](https://github.com/Comcast/react-data-grid) - Feature-rich and customizable data grid React component
+- [xexcel](https://github.com/ximing/xexcel) - Embeddable Excel-style spreadsheet with a State/Transaction/Plugin kernel and formula engine
 
 #### React Maps
 


### PR DESCRIPTION
Add [xexcel](https://github.com/ximing/xexcel) under React Tables and Grids.

Embeddable Excel-style spreadsheet with a State/Transaction/Plugin kernel and formula engine.

- Demo: https://ximing.github.io/xexcel/
- npm: `@xexcel/react`