### PR TITLE
Add tabox to React Real Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ A collection of awesome things regarding the React ecosystem.
 - [readest](https://github.com/readest/readest) - A minimalistic, feature-rich and cross-platform eBook reader
 - [bookcars](https://github.com/aelassas/bookcars) - Car rental platform
 - [notifuse](https://github.com/Notifuse/notifuse) - Modern self-hosted emailing platform to send newsletters & transactional emails
+- [tabox](https://github.com/gilgold/tabox) - Browser extension to save tabs and tab groups into collections and restore sessions in one click
 
 ### React Native
 


### PR DESCRIPTION
Adds [Tabox](https://www.tabox.co) — a free, open-source browser extension ([repo](https://github.com/gilgold/tabox)) that saves all open tabs and tab groups into named collections and restores the exact session (windows, groups, colors, order) in one click. Google Drive sync, share-via-link, optional AI organizer. Works on Chrome, Edge and Firefox.

Disclosure: I'm the developer of Tabox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)