### PR TITLE
Add speedy-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A collection of awesome things regarding the React ecosystem.
 #### React Routing
 
 - [react-router](https://github.com/remix-run/react-router) - Declarative routing for React
+- [speedy-router](https://github.com/anonrig/router) - TanStack Router API rebuilt for faster navigations and SSR
 - [tanstack-router](https://github.com/TanStack/router) - Type-safe router with built-in caching & URL state management
 
 #### React Development Tools


### PR DESCRIPTION
Adds [speedy-router](https://github.com/anonrig/router) to **React Routing**.

[speedy-router](https://github.com/anonrig/router) is a from-scratch React 19.2 router that keeps the TanStack Router public API (`createRouter`, `Link`, loaders, search params, nested routes) and rebuilds the hot path for faster navigations and streaming SSR.

It sits next to `react-router` and `tanstack-router` in the same section.