### PR TITLE
Add xprem to React Native Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ A collection of awesome things regarding the React ecosystem.
 - [realm-js](https://github.com/realm/realm-js) - A mobile database: an alternative to SQLite & key-value stores
 - [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) - Device Information for React Native iOS and Android
 - [react-native-maps](https://github.com/react-native-maps/react-native-maps) - React Native Mapview component
+- [xprem](https://github.com/mercuretechnologies/xprem) - Self-hosted OTA updates for Expo and React Native apps
 
 ### Contribution
 


### PR DESCRIPTION
Adds xprem to React Native Libraries.

xprem is a self-hosted OTA update server for Expo and React Native. It implements the official [Expo Updates protocol](https://docs.expo.dev/technical-specs/expo-updates-1/), so an app already running `expo-updates` can point at it with a config change and no extra native code. Bundles and assets stay in your own bucket and are served from your own CDN. It also covers channel and branch mapping, progressive rollouts, instant rollbacks and end-to-end code signing.

The project is free and open source under MIT, apart from a few `ee/` directories that carry a separate enterprise license.
It is at ~500 stars, has been serving production traffic since early 2025, and the latest release is `v3.1.2` (August 2026). It was previously released as `expo-open-ota`.

Disclosure: I'm the author and maintainer of xprem. Happy to close this if a server-side tool is out of scope for the list.
