### PR TITLE
Add snapcn to React Graphics and Animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-email](https://github.com/resend/react-email) - Unstyled components for creating beautiful emails
 - [8bitcn-ui](https://github.com/TheOrcDev/8bitcn-ui) - A retro 8-bit themed React component library built on top of shadcn
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
+- [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
 
 #### React State Management and Data Fetching
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ A collection of awesome things regarding the React ecosystem.
 - [react-tsparticles](https://github.com/matteobruni/tsparticles) - Easily create highly customizable particles effects
 - [react-parallax-tilt](https://github.com/mkosir/react-parallax-tilt) - Easily apply tilt hover effect on React components
 - [simple-parallax-js](https://github.com/geosigno/simpleParallax.js) - The easiest way to get a parallax effect with React and JavaScript
+- [snapcn](https://github.com/snapcndev/snapcn) - Animations, transitions and backgrounds for building video with Remotion
 
 #### React Integration
 


### PR DESCRIPTION
Adding [snapcn](https://github.com/snapcndev/snapcn) under **React Graphics and Animations**.

It's a set of animations, transitions and backgrounds for [Remotion](https://www.remotion.dev), so the same `useCurrentFrame()` / `interpolate()` / `spring()` primitives the rest of that section uses, but rendered out to video rather than run in the DOM. 33 components, MIT, no paid gate on any of them.

Free and open source, as the contribution note asks.
