### PR TITLE
Add remotion-ui to React Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A collection of awesome things regarding the React ecosystem.
 - [headlessui](https://github.com/tailwindlabs/headlessui) - Completely unstyled, accessible UI components for React
 - [ruixen-ui](https://github.com/ruixenui/ruixen.com) - Modern, lightweight React component library with elegant design
 - [billingsdk](https://github.com/dodopayments/billingsdk) - Type-safe billing and subscription components built with TypeScript, Tailwind CSS and shadcn/ui
+- [remotion-ui](https://github.com/riaz37/remotion-ui) - 200 copy-paste components for building videos with Remotion
 
 #### React State Management and Data Fetching
 


### PR DESCRIPTION
Adds [remotion-ui](https://github.com/riaz37/remotion-ui) to the React Component Libraries section.

remotion-ui provides 200 copy-paste (shadcn-style) components for building videos with Remotion — motion primitives, scenes, captions, transitions, and full video compositions, installed via CLI and owned as plain `.tsx` in the consumer's repo.