### PR TITLE
Add why-did-you-fetch to React Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ A collection of awesome things regarding the React ecosystem.
 - [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) - React specific linting rules for ESLint
 - [react-scan](https://github.com/aidenybai/react-scan) - Scan for React performance issues and eliminate slow renders in your app
 - [why-did-you-render](https://github.com/welldone-software/why-did-you-render) - Monkey patches React to notify you about avoidable re-renders
+- [why-did-you-fetch](https://github.com/kuttim/why-did-you-fetch) - Monkey patches fetch/XHR to notify you about avoidable duplicate and sequential network requests
 
 #### React Libraries
 


### PR DESCRIPTION
Adds [why-did-you-fetch](https://github.com/kuttim/why-did-you-fetch) to the React Development Tools section, alongside why-did-you-render.

It monkey-patches `fetch`/`XMLHttpRequest` to warn about duplicate in-flight requests, redundant recent duplicates, request waterfalls, and N+1-style list-fetch storms — the same idea as why-did-you-render (instrument something ubiquitous, stay quiet until something's actually wrong), applied to the network tab instead of the render tree.

MIT licensed, TypeScript, has a [live interactive demo](https://kuttim.github.io/why-did-you-fetch/) with no install required, and runnable example projects for Vite+React and Next.js App Router.